### PR TITLE
Fix markup typos and remove leftover script

### DIFF
--- a/00 Intro.md
+++ b/00 Intro.md
@@ -180,7 +180,7 @@ var colors: Set<String> = ["red", "green", "blue"]
 #### Empty sets
 
 ```swift
-var emptySet = Set<String>() // Type inferance
+var emptySet = Set<String>() // Type inference
 var emptySet: Set<Int> = []  // Type annotation
 ```
 <br/>
@@ -242,7 +242,7 @@ print(employee["name", default: "Unknown"])   // ➡️  "Taylor Swift"
 #### Empty dictionaries
 
 ```swift
-var emptyDictionary = [String: String]() // Type inferance
+var emptyDictionary = [String: String]() // Type inference
 var emptyDictionary: [Int: Int] = [:]    // Type annotation   
 ```
 

--- a/03 Arrays, Sets, Dictionaries, Enumerations.md
+++ b/03 Arrays, Sets, Dictionaries, Enumerations.md
@@ -68,7 +68,7 @@ var colors: Set<String> = ["red", "green", "blue"]
 #### Empty sets
 
 ```swift
-var emptySet = Set<String>() // Type inferance
+var emptySet = Set<String>() // Type inference
 var emptySet: Set<Int> = []  // Type annotation
 ```
 <br/>
@@ -130,7 +130,7 @@ print(employee["name", default: "Unknown"])   // ➡️  "Taylor Swift"
 #### Empty dictionaries
 
 ```swift
-var emptyDictionary = [String: String]() // Type inferance
+var emptyDictionary = [String: String]() // Type inference
 var emptyDictionary: [Int: Int] = [:]    // Type annotation   
 ```
 

--- a/04 Type inference, Type annotation.md
+++ b/04 Type inference, Type annotation.md
@@ -1,7 +1,3 @@
-javascript:document.body.appendChild(document.querySelector("#readme"));document.querySelector("header").remove();document.querySelector(".application-main").remove();document.querySelector("footer").remove();window.print();
-
-# Test
-
 # 🧱 Type Inference 
 <br/>
 

--- a/05 If, Switch, Ternary operator.md
+++ b/05 If, Switch, Ternary operator.md
@@ -75,7 +75,7 @@ Use these to combine multiple conditions:
 | Operator | Name       | Example                           |
 |----------|------------|-----------------------------------|
 | `&&`     | and        | `age >= 18 && citizen == true`    |
-| `\/`     | or         | `isStudent \/ isSenior`           |
+| `||`     | or         | `isStudent || isSenior`           |
 | `!`      | not        | `!hasAccess` means "no access"    |
 
 ---


### PR DESCRIPTION
## Summary
- fix `||` logical operator example
- correct several `Type inference` typos
- remove stray script from the type inference notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f23bf92508331b14363a930121bf1